### PR TITLE
Update date field of transaction to be of type LocalDate and not string

### DIFF
--- a/server/src/main/java/com/neueda/portfolio_management/controller/TransactionController.java
+++ b/server/src/main/java/com/neueda/portfolio_management/controller/TransactionController.java
@@ -3,10 +3,8 @@ package com.neueda.portfolio_management.controller;
 import com.neueda.portfolio_management.entity.Asset;
 import com.neueda.portfolio_management.entity.Transaction;
 import com.neueda.portfolio_management.service.TransactionService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -28,4 +26,9 @@ public class TransactionController {
     public List<Transaction> getAllTransactionsByAsset(@RequestParam String asset) {
         return transactionService.getTransactionsByAsset(asset);
     }
+
+//    @PostMapping
+//    public Transaction createTransaction(@Valid @RequestBody TransactionRequest transactionRequest) {
+//        return transactionService.createTransaction(transactionRequest);
+//    }
 }

--- a/server/src/main/java/com/neueda/portfolio_management/entity/Transaction.java
+++ b/server/src/main/java/com/neueda/portfolio_management/entity/Transaction.java
@@ -1,8 +1,12 @@
 package com.neueda.portfolio_management.entity;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.neueda.portfolio_management.converter.TransactionTypeConverter;
 import com.neueda.portfolio_management.enums.TransactionType;
 import jakarta.persistence.*;
+import org.springframework.cglib.core.Local;
+
+import java.time.LocalDate;
 
 @Entity
 public class Transaction {
@@ -17,14 +21,15 @@ public class Transaction {
     @JoinColumn(name = "asset", nullable = false)
     private Asset asset;
 
-    private String date;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
     private Long quantity;
     private Double pricePerUnitInUSD;
 
     public Transaction() {
     }
 
-    public Transaction(Long id, TransactionType type, Asset asset, String date, Long quantity, Double pricePerUnitInUSD) {
+    public Transaction(Long id, TransactionType type, Asset asset, LocalDate date, Long quantity, Double pricePerUnitInUSD) {
         this.id = id;
         this.type = type;
         this.asset = asset;
@@ -57,11 +62,11 @@ public class Transaction {
         this.asset = asset;
     }
 
-    public String getDate() {
+    public LocalDate getDate() {
         return date;
     }
 
-    public void setDate(String date) {
+    public void setDate(LocalDate date) {
         this.date = date;
     }
 

--- a/server/src/main/resources/data.sql
+++ b/server/src/main/resources/data.sql
@@ -6,5 +6,5 @@ values
 
 insert into transaction (DATE, TYPE, ASSET, QUANTITY, PRICE_PER_UNIT_INUSD)
 values
-    ('23-12-2024', 'BuY', 1, 100, 1250),
-    ('12-09-2025', 'SELl', 2, 50, 560);
+    ('2024-12-23', 'BuY', 1, 100, 1250),
+    ('2025-09-12', 'SELl', 2, 50, 560);

--- a/server/src/test/java/com/neueda/portfolio_management/controller/TransactionControllerTest.java
+++ b/server/src/test/java/com/neueda/portfolio_management/controller/TransactionControllerTest.java
@@ -70,9 +70,7 @@ public class TransactionControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(1))
                 .andExpect(jsonPath("$[0].id").value(10))
-                .andExpect(jsonPath("$[0].date[0]").value(2023)) // year
-                .andExpect(jsonPath("$[0].date[1]").value(2)) // month
-                .andExpect(jsonPath("$[0].date[2]").value(2)) // day
+                .andExpect(jsonPath("$[0].date").value("2023-02-02"))
                 .andExpect(jsonPath("$[0].quantity").value(50))
                 // enum serialized as string
                 .andExpect(jsonPath("$[0].type").value(TransactionType.values()[0].name()))

--- a/server/src/test/java/com/neueda/portfolio_management/controller/TransactionControllerTest.java
+++ b/server/src/test/java/com/neueda/portfolio_management/controller/TransactionControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -32,8 +33,8 @@ public class TransactionControllerTest {
 
     @Test
     public void getAllTransactions_returnsList() throws Exception {
-        Transaction t1 = new Transaction(1L, TransactionType.values()[0], new Asset(), "2023-01-01", 10L, 5.0);
-        Transaction t2 = new Transaction(2L, TransactionType.values()[0], new Asset(), "2023-01-02", 20L, 6.0);
+        Transaction t1 = new Transaction(1L, TransactionType.values()[0], new Asset(), LocalDate.of(2023, 1, 1), 10L, 5.0);
+        Transaction t2 = new Transaction(2L, TransactionType.values()[0], new Asset(), LocalDate.of(2023, 1, 2), 20L, 6.0);
 
         when(transactionService.getAllTransactions()).thenReturn(Arrays.asList(t1, t2));
 
@@ -48,7 +49,7 @@ public class TransactionControllerTest {
     @Test
     public void getAllTransactionsByAsset_callsServiceWithParam() throws Exception {
         String assetName = "ETH";
-        Transaction t = new Transaction(3L, TransactionType.values()[0], new Asset(), "2023-01-03", 5L, 1.2);
+        Transaction t = new Transaction(3L, TransactionType.values()[0], new Asset(), LocalDate.of(2023, 1, 3), 5L, 1.2);
         when(transactionService.getTransactionsByAsset(assetName)).thenReturn(Arrays.asList(t));
 
         mockMvc.perform(get("/transactions").param("asset", assetName).accept(MediaType.APPLICATION_JSON))
@@ -62,14 +63,16 @@ public class TransactionControllerTest {
     @Test
     public void getAllTransactions_returnsDetailedJson() throws Exception {
         Asset asset = new Asset(11L, "BTC", "crypto", 150.5);
-        Transaction tx = new Transaction(10L, TransactionType.values()[0], asset, "2023-02-02", 50L, 1234.5);
+        Transaction tx = new Transaction(10L, TransactionType.values()[0], asset, LocalDate.of(2023, 2, 2), 50L, 1234.5);
         when(transactionService.getAllTransactions()).thenReturn(Arrays.asList(tx));
 
         mockMvc.perform(get("/transactions").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.length()").value(1))
                 .andExpect(jsonPath("$[0].id").value(10))
-                .andExpect(jsonPath("$[0].date").value("2023-02-02"))
+                .andExpect(jsonPath("$[0].date[0]").value(2023)) // year
+                .andExpect(jsonPath("$[0].date[1]").value(2)) // month
+                .andExpect(jsonPath("$[0].date[2]").value(2)) // day
                 .andExpect(jsonPath("$[0].quantity").value(50))
                 // enum serialized as string
                 .andExpect(jsonPath("$[0].type").value(TransactionType.values()[0].name()))

--- a/server/src/test/java/com/neueda/portfolio_management/entity/TransactionTest.java
+++ b/server/src/test/java/com/neueda/portfolio_management/entity/TransactionTest.java
@@ -4,6 +4,7 @@ import com.neueda.portfolio_management.enums.TransactionType;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -12,12 +13,12 @@ public class TransactionTest {
     @Test
     public void constructorAndGetters_shouldReturnValues() {
         Asset asset = new Asset(); // ...existing code... (use default constructor from project)
-        Transaction tx = new Transaction(1L, TransactionType.values()[0], asset, "2023-01-01", 100L, 12.34);
+        Transaction tx = new Transaction(1L, TransactionType.values()[0], asset, LocalDate.parse("2023-01-01"), 100L, 12.34);
 
         assertEquals(1L, tx.getId());
         assertEquals(TransactionType.values()[0], tx.getType());
         assertSame(asset, tx.getAsset());
-        assertEquals("2023-01-01", tx.getDate());
+        assertEquals(LocalDate.parse("2023-01-01"), tx.getDate());
         assertEquals(100L, tx.getQuantity());
         // use reflection because the public getter/setter for price may not exist in the entity
         assertEquals(Double.valueOf(12.34), getPrice(tx));
@@ -38,8 +39,8 @@ public class TransactionTest {
         tx.setAsset(asset);
         assertSame(asset, tx.getAsset());
 
-        tx.setDate("2020-12-31");
-        assertEquals("2020-12-31", tx.getDate());
+        tx.setDate(LocalDate.parse("2020-12-31"));
+        assertEquals(LocalDate.parse("2020-12-31"), tx.getDate());
 
         tx.setQuantity(250L);
         assertEquals(250L, tx.getQuantity());


### PR DESCRIPTION
To allow for transaction sorting by date, the date field was changes from String type to LocalDate type. 