### PR TITLE
Create-transaction endpoint

### DIFF
--- a/server/src/main/java/com/neueda/portfolio_management/controller/TransactionController.java
+++ b/server/src/main/java/com/neueda/portfolio_management/controller/TransactionController.java
@@ -1,5 +1,6 @@
 package com.neueda.portfolio_management.controller;
 
+import com.neueda.portfolio_management.dto.TransactionRequest;
 import com.neueda.portfolio_management.entity.Asset;
 import com.neueda.portfolio_management.entity.Transaction;
 import com.neueda.portfolio_management.service.TransactionService;
@@ -27,8 +28,8 @@ public class TransactionController {
         return transactionService.getTransactionsByAsset(asset);
     }
 
-//    @PostMapping
-//    public Transaction createTransaction(@Valid @RequestBody TransactionRequest transactionRequest) {
-//        return transactionService.createTransaction(transactionRequest);
-//    }
+    @PostMapping
+    public Transaction createTransaction(@Valid @RequestBody TransactionRequest transactionRequest) {
+        return transactionService.createTransaction(transactionRequest);
+    }
 }

--- a/server/src/main/java/com/neueda/portfolio_management/dto/ErrorResponse.java
+++ b/server/src/main/java/com/neueda/portfolio_management/dto/ErrorResponse.java
@@ -1,0 +1,24 @@
+package com.neueda.portfolio_management.dto;
+
+import java.time.LocalDateTime;
+
+public class ErrorResponse {
+
+    private int status;
+    private String message;
+    private LocalDateTime timestamp;
+
+    public ErrorResponse(int status, String message) {
+        this.status = status;
+        this.message = message;
+        this.timestamp = LocalDateTime.now();
+    }
+
+    // getters and setters
+    public int getStatus() { return status; }
+    public void setStatus(int status) { this.status = status; }
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+    public LocalDateTime getTimestamp() { return timestamp; }
+    public void setTimestamp(LocalDateTime timestamp) { this.timestamp = timestamp; }
+}

--- a/server/src/main/java/com/neueda/portfolio_management/dto/TransactionRequest.java
+++ b/server/src/main/java/com/neueda/portfolio_management/dto/TransactionRequest.java
@@ -1,0 +1,85 @@
+package com.neueda.portfolio_management.dto;
+
+import com.neueda.portfolio_management.enums.TransactionType;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.time.LocalDate;
+
+public class TransactionRequest {
+    @NotNull(message = "Date of transaction is missing")
+    private LocalDate date;
+
+    @NotNull(message = "Transaction type is missing")
+    private TransactionType type;
+
+    @Positive
+    @NotNull(message = "Transaction quantity is missing")
+    private Double quantity;
+
+    @Positive
+    @NotNull(message = "Price per unit is missing")
+    private Double pricePerUnit;
+
+    // both the id and an asset object can be provided in the request
+    // in such a case, the id should take precedence and the asset object should be discarded
+    private Long assetId;
+    private String assetName;
+    private String assetType;
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
+
+    public TransactionType getType() {
+        return type;
+    }
+
+    public void setType(TransactionType type) {
+        this.type = type;
+    }
+
+    public Double getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Double quantity) {
+        this.quantity = quantity;
+    }
+
+    public Double getPricePerUnit() {
+        return pricePerUnit;
+    }
+
+    public void setPricePerUnit(Double pricePerUnit) {
+        this.pricePerUnit = pricePerUnit;
+    }
+
+    public Long getAssetId() {
+        return assetId;
+    }
+
+    public void setAssetId(Long assetId) {
+        this.assetId = assetId;
+    }
+
+    public String getAssetName() {
+        return assetName;
+    }
+
+    public void setAssetName(String assetName) {
+        this.assetName = assetName;
+    }
+
+    public String getAssetType() {
+        return assetType;
+    }
+
+    public void setAssetType(String assetType) {
+        this.assetType = assetType;
+    }
+}

--- a/server/src/main/java/com/neueda/portfolio_management/entity/Transaction.java
+++ b/server/src/main/java/com/neueda/portfolio_management/entity/Transaction.java
@@ -23,19 +23,19 @@ public class Transaction {
 
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate date;
-    private Long quantity;
-    private Double pricePerUnitInUSD;
+    private Double quantity;
+    private Double pricePerUnit;
 
     public Transaction() {
     }
 
-    public Transaction(Long id, TransactionType type, Asset asset, LocalDate date, Long quantity, Double pricePerUnitInUSD) {
+    public Transaction(Long id, TransactionType type, Asset asset, LocalDate date, Double quantity, Double pricePerUnit) {
         this.id = id;
         this.type = type;
         this.asset = asset;
         this.date = date;
         this.quantity = quantity;
-        this.pricePerUnitInUSD = pricePerUnitInUSD;
+        this.pricePerUnit = pricePerUnit;
     }
 
     public Long getId() {
@@ -70,19 +70,19 @@ public class Transaction {
         this.date = date;
     }
 
-    public Long getQuantity() {
+    public Double getQuantity() {
         return quantity;
     }
 
-    public void setQuantity(Long quantity) {
+    public void setQuantity(Double quantity) {
         this.quantity = quantity;
     }
 
-    public Double getPrice() {
-        return pricePerUnitInUSD;
+    public Double getPricePerUnit() {
+        return pricePerUnit;
     }
 
-    public void setPrice(Double pricePerUnitInUSD) {
-        this.pricePerUnitInUSD = pricePerUnitInUSD;
+    public void setPricePerUnit(Double pricePerUnit) {
+        this.pricePerUnit = pricePerUnit;
     }
 }

--- a/server/src/main/java/com/neueda/portfolio_management/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/neueda/portfolio_management/exception/GlobalExceptionHandler.java
@@ -1,0 +1,48 @@
+package com.neueda.portfolio_management.exception;
+
+import com.neueda.portfolio_management.dto.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.http.ResponseEntity;
+
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNotFound(NotFoundException ex) {
+        ErrorResponse error = new ErrorResponse(HttpStatus.NOT_FOUND.value(), ex.getMessage());
+        return new ResponseEntity<>(error, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(InvalidAssetException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidAsset(InvalidAssetException ex) {
+        ErrorResponse error = new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage());
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(InvalidTransactionException.class)
+    public ResponseEntity<ErrorResponse> handleInvalidTransaction(InvalidTransactionException ex) {
+        ErrorResponse error = new ErrorResponse(HttpStatus.BAD_REQUEST.value(), ex.getMessage());
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationErrors(MethodArgumentNotValidException ex) {
+        String messages = ex.getBindingResult().getFieldErrors()
+                .stream()
+                .map(e -> e.getField() + ": " + e.getDefaultMessage())
+                .collect(Collectors.joining("; "));
+        ErrorResponse error = new ErrorResponse(HttpStatus.BAD_REQUEST.value(), messages);
+        return new ResponseEntity<>(error, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGeneralError(Exception ex) {
+        ErrorResponse error = new ErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), "Something went wrong");
+        return new ResponseEntity<>(error, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/server/src/main/java/com/neueda/portfolio_management/exception/InvalidAssetException.java
+++ b/server/src/main/java/com/neueda/portfolio_management/exception/InvalidAssetException.java
@@ -1,0 +1,11 @@
+package com.neueda.portfolio_management.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+public class InvalidAssetException extends RuntimeException {
+    public InvalidAssetException(String message) {
+        super(message);
+    }
+}

--- a/server/src/main/java/com/neueda/portfolio_management/exception/InvalidTransactionException.java
+++ b/server/src/main/java/com/neueda/portfolio_management/exception/InvalidTransactionException.java
@@ -1,0 +1,11 @@
+package com.neueda.portfolio_management.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.BAD_REQUEST)
+public class InvalidTransactionException extends RuntimeException {
+    public InvalidTransactionException(String message) {
+        super(message);
+    }
+}

--- a/server/src/main/java/com/neueda/portfolio_management/exception/NotFoundException.java
+++ b/server/src/main/java/com/neueda/portfolio_management/exception/NotFoundException.java
@@ -1,0 +1,12 @@
+package com.neueda.portfolio_management.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class NotFoundException extends RuntimeException {
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/server/src/main/java/com/neueda/portfolio_management/repository/AssetRepository.java
+++ b/server/src/main/java/com/neueda/portfolio_management/repository/AssetRepository.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface AssetRepository extends JpaRepository<Asset, Long> {
-    public List<Asset> findAllByNameContainingIgnoreCase(String name);
+    public List<Asset> findAll();
+    public List<Asset> findAllByQuantityGreaterThan(Double quantity);
+    public List<Asset> findAllByNameContainingIgnoreCaseAndQuantityGreaterThan(String name, Double quantity);
     public Optional<Asset> findByName(String name);
 }

--- a/server/src/main/java/com/neueda/portfolio_management/repository/AssetRepository.java
+++ b/server/src/main/java/com/neueda/portfolio_management/repository/AssetRepository.java
@@ -4,7 +4,9 @@ import com.neueda.portfolio_management.entity.Asset;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AssetRepository extends JpaRepository<Asset, Long> {
     public List<Asset> findAllByNameContainingIgnoreCase(String name);
+    public Optional<Asset> findByName(String name);
 }

--- a/server/src/main/java/com/neueda/portfolio_management/repository/TransactionRepository.java
+++ b/server/src/main/java/com/neueda/portfolio_management/repository/TransactionRepository.java
@@ -6,5 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface TransactionRepository extends JpaRepository<Transaction, Long> {
+    public List<Transaction> findAll();
+    public List<Transaction> findAllByOrderByDateAsc();
     public List<Transaction> findAllByAssetNameIgnoreCaseOrderByDateAsc(String assetName);
 }

--- a/server/src/main/java/com/neueda/portfolio_management/service/AssetServiceImpl.java
+++ b/server/src/main/java/com/neueda/portfolio_management/service/AssetServiceImpl.java
@@ -21,7 +21,7 @@ public class AssetServiceImpl implements AssetService{
 
     @Override
     public List<Asset> getAllAssets(){
-        return assetRepository.findAll();
+        return assetRepository.findAllByQuantityGreaterThan(0.0);
     }
 
     @Override
@@ -38,7 +38,7 @@ public class AssetServiceImpl implements AssetService{
 
     @Override
     public List<Asset> getAssetsByName(String name){
-        return assetRepository.findAllByNameContainingIgnoreCase(name);
+        return assetRepository.findAllByNameContainingIgnoreCaseAndQuantityGreaterThan(name, 0.0);
     }
 
     @Override

--- a/server/src/main/java/com/neueda/portfolio_management/service/TransactionService.java
+++ b/server/src/main/java/com/neueda/portfolio_management/service/TransactionService.java
@@ -1,5 +1,6 @@
 package com.neueda.portfolio_management.service;
 
+import com.neueda.portfolio_management.dto.TransactionRequest;
 import com.neueda.portfolio_management.entity.Transaction;
 
 import java.util.List;
@@ -7,4 +8,5 @@ import java.util.List;
 public interface TransactionService {
     public List<Transaction> getAllTransactions();
     public List<Transaction> getTransactionsByAsset(String asset);
+    public Transaction createTransaction(TransactionRequest transactionRequest);
 }

--- a/server/src/main/java/com/neueda/portfolio_management/service/TransactionServiceImpl.java
+++ b/server/src/main/java/com/neueda/portfolio_management/service/TransactionServiceImpl.java
@@ -1,7 +1,14 @@
 package com.neueda.portfolio_management.service;
 
+import com.neueda.portfolio_management.dto.TransactionRequest;
+import com.neueda.portfolio_management.entity.Asset;
 import com.neueda.portfolio_management.entity.Transaction;
+import com.neueda.portfolio_management.enums.TransactionType;
+import com.neueda.portfolio_management.exception.InvalidAssetException;
+import com.neueda.portfolio_management.exception.NotFoundException;
+import com.neueda.portfolio_management.repository.AssetRepository;
 import com.neueda.portfolio_management.repository.TransactionRepository;
+import com.neueda.portfolio_management.exception.InvalidTransactionException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -10,9 +17,11 @@ import java.util.List;
 //@Profile("db")
 public class TransactionServiceImpl implements TransactionService {
     private TransactionRepository transactionRepository;
+    private AssetRepository assetRepository;
 
-    public TransactionServiceImpl(TransactionRepository transactionRepository) {
+    public TransactionServiceImpl(TransactionRepository transactionRepository, AssetRepository assetRepository) {
         this.transactionRepository = transactionRepository;
+        this.assetRepository = assetRepository;
     }
 
     @Override
@@ -23,5 +32,85 @@ public class TransactionServiceImpl implements TransactionService {
     @Override
     public List<Transaction> getTransactionsByAsset(String asset){
         return transactionRepository.findAllByAssetNameIgnoreCase(asset);
+    }
+
+    @Override
+    public Transaction createTransaction(TransactionRequest transactionRequest){
+        Asset asset;
+        if (transactionRequest.getAssetId() != null) {  // if id of the asset is provided, i.e. we expect the asset to be in the portfolio
+            asset = assetRepository.findById(transactionRequest.getAssetId())
+                    .orElseThrow(() -> new NotFoundException("Asset not found in portfolio"));
+
+            // if we get here, asset exists in the portfolio
+
+            TransactionType transactionType = transactionRequest.getType();
+
+            // update the asset based on transaction type
+            switch (transactionType) {
+                case BUY:
+                    asset.setQuantity(asset.getQuantity().doubleValue() + transactionRequest.getQuantity().doubleValue());
+                    asset = assetRepository.saveAndFlush(asset);
+                    break;
+                case SELL:
+                    double newQuantity = asset.getQuantity().doubleValue() - transactionRequest.getQuantity().doubleValue();
+
+                    if (newQuantity < 0)
+                        throw new InvalidTransactionException("Invalid transaction quantity. Cannot be more that the current quantity of the asset");
+
+                   asset.setQuantity(newQuantity);
+                   asset = assetRepository.saveAndFlush(asset);
+
+                    break;
+            }
+
+            Transaction transaction = new Transaction();
+            transaction.setAsset(asset);
+            transaction.setQuantity(transactionRequest.getQuantity());
+            transaction.setDate(transactionRequest.getDate());
+            transaction.setType(transactionType);
+            transaction.setPricePerUnit(transactionRequest.getPricePerUnit());
+
+            return transactionRepository.saveAndFlush(transaction);
+
+        } else {
+            if(transactionRequest.getAssetName() == null || transactionRequest.getAssetType() == null)
+                throw new InvalidAssetException("Invalid asset specification. Need to specify assetName and assetType");
+
+            if(transactionRequest.getAssetName().isEmpty() || transactionRequest.getAssetType().isEmpty())
+                throw new InvalidAssetException("Invalid asset specification. assetName and assetType cannot be empty");
+
+            asset = assetRepository.findByName(transactionRequest.getAssetName()).orElse(null);
+
+            if(asset == null) {
+                asset = new Asset();
+                asset.setName(transactionRequest.getAssetName());
+                asset.setType(transactionRequest.getAssetType());
+                asset.setQuantity(0.0);
+            }
+
+            switch (transactionRequest.getType()) {
+                case BUY:
+                    asset.setQuantity(asset.getQuantity() + transactionRequest.getQuantity().doubleValue());
+                    break;
+                case SELL:
+                    double newQuantity = asset.getQuantity().doubleValue() - transactionRequest.getQuantity().doubleValue();
+                    if(newQuantity < 0)
+                        throw new InvalidTransactionException("Invalid transaction quantity. Cannot be more that the current quantity of the asset");
+
+                    asset.setQuantity(newQuantity);
+                    break;
+            }
+
+            assetRepository.saveAndFlush(asset);
+
+            Transaction transaction = new Transaction();
+            transaction.setAsset(asset);
+            transaction.setQuantity(transactionRequest.getQuantity());
+            transaction.setDate(transactionRequest.getDate());
+            transaction.setType(transactionRequest.getType());
+            transaction.setPricePerUnit(transactionRequest.getPricePerUnit());
+
+            return transactionRepository.saveAndFlush(transaction);
+        }
     }
 }

--- a/server/src/main/java/com/neueda/portfolio_management/service/TransactionServiceImpl.java
+++ b/server/src/main/java/com/neueda/portfolio_management/service/TransactionServiceImpl.java
@@ -26,7 +26,7 @@ public class TransactionServiceImpl implements TransactionService {
 
     @Override
     public List<Transaction> getAllTransactions(){
-        return transactionRepository.findAll();
+        return transactionRepository.findAllByOrderByDateAsc();
     }
 
     @Override

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -13,3 +13,5 @@ spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.defer-datasource-initialization=true
 
 spring.profiles.active=db
+
+spring.jackson.mapper.accept-case-insensitive-enums=true

--- a/server/src/main/resources/data.sql
+++ b/server/src/main/resources/data.sql
@@ -4,7 +4,7 @@ values
     ('Silver', 'commodity', 45.5),
     ('Appl', 'stock', 333.333);
 
-insert into transaction (DATE, TYPE, ASSET, QUANTITY, PRICE_PER_UNIT_INUSD)
+insert into transaction (DATE, TYPE, ASSET, QUANTITY, PRICE_PER_UNIT)
 values
     ('2024-12-23', 'BuY', 1, 100, 1250),
     ('2025-09-12', 'SELl', 2, 50, 560);

--- a/server/src/test/java/com/neueda/portfolio_management/controller/TransactionControllerTest.java
+++ b/server/src/test/java/com/neueda/portfolio_management/controller/TransactionControllerTest.java
@@ -33,8 +33,8 @@ public class TransactionControllerTest {
 
     @Test
     public void getAllTransactions_returnsList() throws Exception {
-        Transaction t1 = new Transaction(1L, TransactionType.values()[0], new Asset(), LocalDate.of(2023, 1, 1), 10L, 5.0);
-        Transaction t2 = new Transaction(2L, TransactionType.values()[0], new Asset(), LocalDate.of(2023, 1, 2), 20L, 6.0);
+        Transaction t1 = new Transaction(1L, TransactionType.values()[0], new Asset(), LocalDate.of(2023, 1, 1), 10.0, 5.0);
+        Transaction t2 = new Transaction(2L, TransactionType.values()[0], new Asset(), LocalDate.of(2023, 1, 2), 20.0, 6.0);
 
         when(transactionService.getAllTransactions()).thenReturn(Arrays.asList(t1, t2));
 
@@ -49,7 +49,7 @@ public class TransactionControllerTest {
     @Test
     public void getAllTransactionsByAsset_callsServiceWithParam() throws Exception {
         String assetName = "ETH";
-        Transaction t = new Transaction(3L, TransactionType.values()[0], new Asset(), LocalDate.of(2023, 1, 3), 5L, 1.2);
+        Transaction t = new Transaction(3L, TransactionType.values()[0], new Asset(), LocalDate.of(2023, 1, 3), 5.0, 1.2);
         when(transactionService.getTransactionsByAsset(assetName)).thenReturn(Arrays.asList(t));
 
         mockMvc.perform(get("/transactions").param("asset", assetName).accept(MediaType.APPLICATION_JSON))
@@ -63,7 +63,7 @@ public class TransactionControllerTest {
     @Test
     public void getAllTransactions_returnsDetailedJson() throws Exception {
         Asset asset = new Asset(11L, "BTC", "crypto", 150.5);
-        Transaction tx = new Transaction(10L, TransactionType.values()[0], asset, LocalDate.of(2023, 2, 2), 50L, 1234.5);
+        Transaction tx = new Transaction(10L, TransactionType.values()[0], asset, LocalDate.of(2023, 2, 2), 50.0, 1234.5);
         when(transactionService.getAllTransactions()).thenReturn(Arrays.asList(tx));
 
         mockMvc.perform(get("/transactions").accept(MediaType.APPLICATION_JSON))
@@ -71,7 +71,7 @@ public class TransactionControllerTest {
                 .andExpect(jsonPath("$.length()").value(1))
                 .andExpect(jsonPath("$[0].id").value(10))
                 .andExpect(jsonPath("$[0].date").value("2023-02-02"))
-                .andExpect(jsonPath("$[0].quantity").value(50))
+                .andExpect(jsonPath("$[0].quantity").value(50.0))
                 // enum serialized as string
                 .andExpect(jsonPath("$[0].type").value(TransactionType.values()[0].name()))
                 // nested asset fields

--- a/server/src/test/java/com/neueda/portfolio_management/entity/TransactionTest.java
+++ b/server/src/test/java/com/neueda/portfolio_management/entity/TransactionTest.java
@@ -13,13 +13,13 @@ public class TransactionTest {
     @Test
     public void constructorAndGetters_shouldReturnValues() {
         Asset asset = new Asset(); // ...existing code... (use default constructor from project)
-        Transaction tx = new Transaction(1L, TransactionType.values()[0], asset, LocalDate.parse("2023-01-01"), 100L, 12.34);
+        Transaction tx = new Transaction(1L, TransactionType.values()[0], asset, LocalDate.parse("2023-01-01"), 100.0, 12.34);
 
         assertEquals(1L, tx.getId());
         assertEquals(TransactionType.values()[0], tx.getType());
         assertSame(asset, tx.getAsset());
         assertEquals(LocalDate.parse("2023-01-01"), tx.getDate());
-        assertEquals(100L, tx.getQuantity());
+        assertEquals(100.0, tx.getQuantity());
         // use reflection because the public getter/setter for price may not exist in the entity
         assertEquals(Double.valueOf(12.34), getPrice(tx));
     }
@@ -42,36 +42,36 @@ public class TransactionTest {
         tx.setDate(LocalDate.parse("2020-12-31"));
         assertEquals(LocalDate.parse("2020-12-31"), tx.getDate());
 
-        tx.setQuantity(250L);
-        assertEquals(250L, tx.getQuantity());
+        tx.setQuantity(250.0);
+        assertEquals(250.0, tx.getQuantity());
 
         // use reflection to set and read pricePerUnitInUSD because setters/getters may be absent
         setPrice(tx, Double.valueOf(99.99));
         assertEquals(Double.valueOf(99.99), getPrice(tx));
     }
 
-    // Reflection helpers to read/write the private pricePerUnitInUSD field reliably
+    // Reflection helpers to read/write the private pricePerUnit field reliably
     private static Double getPrice(Transaction tx) {
         try {
-            Field f = Transaction.class.getDeclaredField("pricePerUnitInUSD");
+            Field f = Transaction.class.getDeclaredField("pricePerUnit");
             f.setAccessible(true);
             return (Double) f.get(tx);
         } catch (NoSuchFieldException nsf) {
-            throw new AssertionError("Field pricePerUnitInUSD not found on Transaction", nsf);
+            throw new AssertionError("Field pricePerUnit not found on Transaction", nsf);
         } catch (IllegalAccessException iae) {
-            throw new AssertionError("Unable to access pricePerUnitInUSD", iae);
+            throw new AssertionError("Unable to access pricePerUnit", iae);
         }
     }
 
     private static void setPrice(Transaction tx, Double value) {
         try {
-            Field f = Transaction.class.getDeclaredField("pricePerUnitInUSD");
+            Field f = Transaction.class.getDeclaredField("pricePerUnit");
             f.setAccessible(true);
             f.set(tx, value);
         } catch (NoSuchFieldException nsf) {
-            throw new AssertionError("Field pricePerUnitInUSD not found on Transaction", nsf);
+            throw new AssertionError("Field pricePerUnit not found on Transaction", nsf);
         } catch (IllegalAccessException iae) {
-            throw new AssertionError("Unable to access pricePerUnitInUSD", iae);
+            throw new AssertionError("Unable to access pricePerUnit", iae);
         }
     }
 }

--- a/server/src/test/java/com/neueda/portfolio_management/service/AssetServiceImplTest.java
+++ b/server/src/test/java/com/neueda/portfolio_management/service/AssetServiceImplTest.java
@@ -34,12 +34,12 @@ class AssetServiceImplTest {
         Asset asset1 = new Asset(1L, "Stock A", "Equity", 150.5);
         Asset asset2 = new Asset(2L, "Bond B", "Fixed Income", 25.0);
 
-        when(assetRepository.findAll()).thenReturn(Arrays.asList(asset1, asset2));
+        when(assetRepository.findAllByQuantityGreaterThan(0.0)).thenReturn(Arrays.asList(asset1, asset2));
 
         List<Asset> result = assetService.getAllAssets();
 
         assertEquals(2, result.size());
-        verify(assetRepository, times(1)).findAll();
+        verify(assetRepository, times(1)).findAllByQuantityGreaterThan(0.0);
     }
 
     @Test

--- a/server/src/test/java/com/neueda/portfolio_management/service/AssetServiceTest.java
+++ b/server/src/test/java/com/neueda/portfolio_management/service/AssetServiceTest.java
@@ -34,12 +34,12 @@ class AssetServiceTest {
         Asset asset1 = new Asset(1L, "Gold", "commodity", 150.5);
         Asset asset2 = new Asset(2L, "Silver", "commodity",  25.0);
 
-        when(assetRepository.findAll()).thenReturn(Arrays.asList(asset1, asset2));
+        when(assetRepository.findAllByQuantityGreaterThan(0.0)).thenReturn(Arrays.asList(asset1, asset2));
 
         List<Asset> result = assetService.getAllAssets();
 
         assertEquals(2, result.size());
-        verify(assetRepository, times(1)).findAll();
+        verify(assetRepository, times(1)).findAllByQuantityGreaterThan(0.0);
     }
 
     @Test

--- a/server/src/test/java/com/neueda/portfolio_management/service/TransactionServiceImplTest.java
+++ b/server/src/test/java/com/neueda/portfolio_management/service/TransactionServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.neueda.portfolio_management.service;
 
 import com.neueda.portfolio_management.entity.Transaction;
+import com.neueda.portfolio_management.repository.AssetRepository;
 import com.neueda.portfolio_management.repository.TransactionRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,37 +15,39 @@ import static org.mockito.Mockito.*;
 
 public class TransactionServiceImplTest {
 
-    private TransactionRepository repository;
+    private TransactionRepository transactionRepository;
+    private AssetRepository assetRepository;
     private TransactionServiceImpl service;
 
     @BeforeEach
     public void setup() {
-        repository = mock(TransactionRepository.class);
-        service = new TransactionServiceImpl(repository);
+        transactionRepository = mock(TransactionRepository.class);
+        assetRepository = mock(AssetRepository.class);
+        service = new TransactionServiceImpl(transactionRepository, assetRepository);
     }
 
     @Test
     public void getAllTransactions_delegatesToRepository() {
         Transaction t1 = new Transaction();
         Transaction t2 = new Transaction();
-        when(repository.findAll()).thenReturn(Arrays.asList(t1, t2));
+        when(transactionRepository.findAll()).thenReturn(Arrays.asList(t1, t2));
 
         List<Transaction> res = service.getAllTransactions();
         assertEquals(2, res.size());
-        verify(repository, times(1)).findAll();
+        verify(transactionRepository, times(1)).findAll();
     }
 
     @Test
     public void getTransactionsByAsset_delegatesToRepository_withExactParam() {
         String assetName = "Bitcoin";
         Transaction t = new Transaction();
-        when(repository.findAllByAssetNameIgnoreCase(assetName)).thenReturn(Arrays.asList(t));
+        when(transactionRepository.findAllByAssetNameIgnoreCase(assetName)).thenReturn(Arrays.asList(t));
 
         List<Transaction> res = service.getTransactionsByAsset(assetName);
         assertEquals(1, res.size());
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-        verify(repository).findAllByAssetNameIgnoreCase(captor.capture());
+        verify(transactionRepository).findAllByAssetNameIgnoreCase(captor.capture());
         assertEquals(assetName, captor.getValue());
     }
 }

--- a/server/src/test/java/com/neueda/portfolio_management/service/TransactionServiceImplTest.java
+++ b/server/src/test/java/com/neueda/portfolio_management/service/TransactionServiceImplTest.java
@@ -1,12 +1,15 @@
 package com.neueda.portfolio_management.service;
 
+import com.neueda.portfolio_management.entity.Asset;
 import com.neueda.portfolio_management.entity.Transaction;
+import com.neueda.portfolio_management.enums.TransactionType;
 import com.neueda.portfolio_management.repository.AssetRepository;
 import com.neueda.portfolio_management.repository.TransactionRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 
@@ -26,16 +29,16 @@ public class TransactionServiceImplTest {
         service = new TransactionServiceImpl(transactionRepository, assetRepository);
     }
 
-    @Test
-    public void getAllTransactions_delegatesToRepository() {
-        Transaction t1 = new Transaction();
-        Transaction t2 = new Transaction();
-        when(transactionRepository.findAll()).thenReturn(Arrays.asList(t1, t2));
-
-        List<Transaction> res = service.getAllTransactions();
-        assertEquals(2, res.size());
-        verify(transactionRepository, times(1)).findAll();
-    }
+//    @Test
+//    public void getAllTransactions_delegatesToRepository() {
+//        Transaction t1 = new Transaction(1L, TransactionType.values()[0], new Asset(), LocalDate.parse("2023-01-01"), 100.0, 12.34);
+//        Transaction t2 = new Transaction(1L, TransactionType.values()[0], new Asset(), LocalDate.parse("2023-01-01"), 100.0, 12.34);
+//        when(transactionRepository.findAllByOrderByDateAsc()).thenReturn(Arrays.asList(t1, t2));
+//
+//        List<Transaction> res = service.getAllTransactions();
+//        assertEquals(2, res.size());
+//        verify(transactionRepository, times(1)).findAll();
+//    }
 
     @Test
     public void getTransactionsByAsset_delegatesToRepository_withExactParam() {

--- a/server/src/test/java/com/neueda/portfolio_management/service/TransactionServiceImplTest.java
+++ b/server/src/test/java/com/neueda/portfolio_management/service/TransactionServiceImplTest.java
@@ -29,16 +29,16 @@ public class TransactionServiceImplTest {
         service = new TransactionServiceImpl(transactionRepository, assetRepository);
     }
 
-//    @Test
-//    public void getAllTransactions_delegatesToRepository() {
-//        Transaction t1 = new Transaction(1L, TransactionType.values()[0], new Asset(), LocalDate.parse("2023-01-01"), 100.0, 12.34);
-//        Transaction t2 = new Transaction(1L, TransactionType.values()[0], new Asset(), LocalDate.parse("2023-01-01"), 100.0, 12.34);
-//        when(transactionRepository.findAllByOrderByDateAsc()).thenReturn(Arrays.asList(t1, t2));
-//
-//        List<Transaction> res = service.getAllTransactions();
-//        assertEquals(2, res.size());
-//        verify(transactionRepository, times(1)).findAll();
-//    }
+    @Test
+    public void getAllTransactions_delegatesToRepository() {
+        Transaction t1 = new Transaction(1L, TransactionType.values()[0], new Asset(), LocalDate.parse("2023-01-01"), 100.0, 12.34);
+        Transaction t2 = new Transaction(1L, TransactionType.values()[0], new Asset(), LocalDate.parse("2023-01-01"), 100.0, 12.34);
+        when(transactionRepository.findAllByOrderByDateAsc()).thenReturn(Arrays.asList(t1, t2));
+
+        List<Transaction> res = service.getAllTransactions();
+        assertEquals(2, res.size());
+        verify(transactionRepository, times(1)).findAllByOrderByDateAsc();
+    }
 
     @Test
     public void getTransactionsByAsset_delegatesToRepository_withExactParam() {


### PR DESCRIPTION
Create-transaction endpoint was implemented to add new transactions and add/modify portfolio assets. Tests were refactored accordingly. In addition, some error handling was implemented so that the server responses are more readable.